### PR TITLE
Bisso newsletter frontend and backend v2

### DIFF
--- a/drupal/config/sync/views.view.newsletter_reg_detail.yml
+++ b/drupal/config/sync/views.view.newsletter_reg_detail.yml
@@ -118,7 +118,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -337,22 +337,76 @@ display:
           value:
             newsletter_registration: newsletter_registration
           group: 1
-        webform_submission_value_1:
-          id: webform_submission_value_1
+        webform_submission_value:
+          id: webform_submission_value
           table: webform_submission_field_newsletter_registration_news
           field: webform_submission_value
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: webform_submission_checkbox_filter
+          plugin_id: webform_submission_field_filter
           operator: '='
-          value: All
+          value: 'Yes'
           group: 1
           exposed: true
           expose:
-            operator_id: ''
+            operator_id: webform_submission_value_op
             label: News
             description: ''
+            use_operator: false
+            operator: webform_submission_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: webform_submission_value
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              next_api_role: '0'
+              wunder_content_editor: '0'
+              frontend_login: '0'
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: News
+            description: ''
+            identifier: webform_submission_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple:
+              1: 1
+              2: 2
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
+        webform_submission_value_1:
+          id: webform_submission_value_1
+          table: webform_submission_field_newsletter_registration_careers
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: webform_submission_field_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: webform_submission_value_1_op
+            label: careers
+            description: null
             use_operator: false
             operator: webform_submission_value_1_op
             operator_limit_selection: false
@@ -363,66 +417,27 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              next_api_role: '0'
-              wunder_content_editor: '0'
-              frontend_login: '0'
-          is_grouped: false
+            placeholder: null
+          is_grouped: true
           group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        webform_submission_value:
-          id: webform_submission_value
-          table: webform_submission_field_newsletter_registration_careers
-          field: webform_submission_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: webform_submission_checkbox_filter
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
             label: Careers
             description: ''
-            use_operator: false
-            operator: webform_submission_value_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: webform_submission_value
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              next_api_role: '0'
-              wunder_content_editor: '0'
-              frontend_login: '0'
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
+            identifier: webform_submission_value_1
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
         webform_submission_value_2:
           id: webform_submission_value_2
           table: webform_submission_field_newsletter_registration_events
@@ -430,15 +445,15 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: webform_submission_checkbox_filter
+          plugin_id: webform_submission_field_filter
           operator: '='
-          value: All
+          value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: ''
-            label: Events
-            description: ''
+            operator_id: webform_submission_value_2_op
+            label: events
+            description: null
             use_operator: false
             operator: webform_submission_value_2_op
             operator_limit_selection: false
@@ -449,23 +464,27 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              next_api_role: '0'
-              wunder_content_editor: '0'
-              frontend_login: '0'
-          is_grouped: false
+            placeholder: null
+          is_grouped: true
           group_info:
-            label: ''
+            label: Events
             description: ''
-            identifier: ''
+            identifier: webform_submission_value_2
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
       filter_groups:
         operator: AND
         groups:

--- a/drupal/config/sync/views.view.newsletter_reg_emails.yml
+++ b/drupal/config/sync/views.view.newsletter_reg_emails.yml
@@ -155,18 +155,27 @@ display:
               next_api_role: '0'
               wunder_content_editor: '0'
               frontend_login: '0'
-          is_grouped: false
+            placeholder: ''
+          is_grouped: true
           group_info:
-            label: ''
+            label: News
             description: ''
-            identifier: ''
+            identifier: webform_submission_value
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
         webform_submission_value_1:
           id: webform_submission_value_1
           table: webform_submission_field_newsletter_registration_careers
@@ -198,18 +207,27 @@ display:
               next_api_role: '0'
               wunder_content_editor: '0'
               frontend_login: '0'
-          is_grouped: false
+            placeholder: ''
+          is_grouped: true
           group_info:
-            label: ''
+            label: Careers
             description: ''
-            identifier: ''
+            identifier: webform_submission_value_1
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
         webform_submission_value_2:
           id: webform_submission_value_2
           table: webform_submission_field_newsletter_registration_events
@@ -241,18 +259,27 @@ display:
               next_api_role: '0'
               wunder_content_editor: '0'
               frontend_login: '0'
-          is_grouped: false
+            placeholder: ''
+          is_grouped: true
           group_info:
-            label: ''
+            label: Events
             description: ''
-            identifier: ''
+            identifier: webform_submission_value_2
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: 'Yes'
+                operator: '='
+                value: 'Yes'
+              2:
+                title: 'No'
+                operator: '='
+                value: 'No'
       style:
         type: default
       row:

--- a/drupal/config/sync/webform.webform.newsletter_registration.yml
+++ b/drupal/config/sync/webform.webform.newsletter_registration.yml
@@ -22,14 +22,17 @@ elements: |-
     '#title': Email
     '#required': true
   news:
-    '#type': checkbox
+    '#type': textfield
     '#title': news
+    '#description': '<p>Yes or No</p>'
   careers:
-    '#type': checkbox
+    '#type': textfield
     '#title': careers
+    '#description': '<p>Yes or No</p>'
   events:
-    '#type': checkbox
+    '#type': textfield
     '#title': events
+    '#description': '<p>Yes or No</p>'
 css: ''
 javascript: ''
 settings:

--- a/next/lib/zod/newsletter-registration.ts
+++ b/next/lib/zod/newsletter-registration.ts
@@ -5,9 +5,9 @@ export const NewsletterRegistrationSchema = z.object({
   privacy: z.boolean().refine((bool) => bool === true, {
     message: "Data consent is required",
   }),
-  news: z.boolean(),
-  careers: z.boolean(),
-  events: z.boolean(),
+  news: z.boolean().or(z.string()),
+  careers: z.boolean().or(z.string()),
+  events: z.boolean().or(z.string()),
 });
 
 export type NewsletterRegistrationType = z.infer<

--- a/next/pages/api/newsletter-registration.ts
+++ b/next/pages/api/newsletter-registration.ts
@@ -17,8 +17,23 @@ export default async function handler(
       const validation = NewsletterRegistrationSchema.safeParse(body);
       // making post request only if the data is valid
       if (validation.success) {
-        // console.log(validation.data);
-        const data = validation.data;
+        // in the drupal news, careers, events input fields are text which takes input either "Yes" or "No". Idealy it shoud be checkbox. But when I create a view for checkbox fields, it has two value either true or empty. But when I add checkbox field for filtering, it gives any, ture and false option. the false should corresponds empty but it does not. So, I have can not filter in or out empty fields. So, I am sending "Yes" for true and "No" for false value. As, news, careers and events field in drupal are textfield, and these fields can be used for filtereing in views.
+        let data = validation.data;
+        if (data.news) {
+          data = { ...data, news: "Yes" };
+        } else {
+          data = { ...data, news: "No" };
+        }
+        if (data.careers) {
+          data = { ...data, careers: "Yes" };
+        } else {
+          data = { ...data, careers: "No" };
+        }
+        if (data.events) {
+          data = { ...data, events: "Yes" };
+        } else {
+          data = { ...data, events: "No" };
+        }
         // Submit to Drupal.
         const result = await drupal.fetch(url.toString(), {
           method: "POST",


### PR DESCRIPTION
# Bisso newsletter frontend and backend v2

in the Drupal news, careers, and events input fields are text which takes input either "Yes" or "No". Idealy, it shoud be checkbox. But when I create a view for checkbox fields, it has two valuea either true or empty (not false). But when I add checkbox field for filtering, it gives any, true, and false options. the false should correspond empty but it does not(empty not equal false). So, I can not filter in or out empty fields. So, I am sending "Yes" for true and "No" for false value from frontend. As, news, careers and events field in Drupal are textfield, and these fields can be used for filtereing in views.